### PR TITLE
feat: add gh_copy_labels script to copy issue labels

### DIFF
--- a/scripts/gh_copy_labels.bash
+++ b/scripts/gh_copy_labels.bash
@@ -1,0 +1,67 @@
+#!/bin/bash
+# gh_copy_labels.bash
+# neko32/tanunekolab_adr の issues label を指定したリポジトリにコピーする
+#
+# Usage: ./gh_copy_labels.bash <target_repo_name>
+# Example: ./gh_copy_labels.bash nekokan_music
+
+set -euo pipefail
+
+SOURCE_REPO="neko32/tanunekolab_adr"
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <target_repo_name>"
+    echo "Example: $0 nekokan_music"
+    exit 1
+fi
+
+TARGET_REPO="neko32/$1"
+
+echo "コピー元: $SOURCE_REPO"
+echo "コピー先: $TARGET_REPO"
+echo ""
+
+# コピー先リポジトリの存在確認
+if ! gh repo view "$TARGET_REPO" > /dev/null 2>&1; then
+    echo "エラー: リポジトリ '$TARGET_REPO' が見つかりません。リポジトリ名を確認してください。" >&2
+    exit 1
+fi
+
+# コピー元のラベル一覧を取得
+echo "ラベル一覧を取得中..."
+labels_json=$(gh label list --repo "$SOURCE_REPO" --json name,color,description --limit 100)
+
+total=$(echo "$labels_json" | jq 'length')
+echo "${total} 件のラベルが見つかりました。"
+echo ""
+
+success=0
+failed=0
+
+while IFS= read -r label; do
+    name=$(echo "$label" | jq -r '.name')
+    color=$(echo "$label" | jq -r '.color')
+    description=$(echo "$label" | jq -r '.description')
+
+    printf "  [%s] をコピー中... " "$name"
+
+    if gh label create "$name" \
+        --color "$color" \
+        --description "$description" \
+        --repo "$TARGET_REPO" \
+        --force > /dev/null 2>&1; then
+        echo "OK"
+        success=$((success + 1))
+    else
+        echo "失敗"
+        failed=$((failed + 1))
+    fi
+
+done < <(echo "$labels_json" | jq -c '.[]')
+
+echo ""
+echo "完了: 成功 ${success} 件 / 失敗 ${failed} 件 (合計 ${total} 件)"
+
+if [ "$failed" -gt 0 ]; then
+    exit 1
+fi

--- a/scripts/gh_copy_labels.ps1
+++ b/scripts/gh_copy_labels.ps1
@@ -1,39 +1,39 @@
 # gh_copy_labels.ps1
-# neko32/tanunekolab_adr の issues label を指定したリポジトリにコピーする
+# Copy issue labels from neko32/tanunekolab_adr to a specified repository
 #
 # Usage: .\gh_copy_labels.ps1 <target_repo_name>
 # Example: .\gh_copy_labels.ps1 nekokan_music
 
 param(
-    [Parameter(Mandatory = $true, HelpMessage = "コピー先のリポジトリ名 (neko32/<name> の <name> 部分)")]
+    [Parameter(Mandatory = $true, HelpMessage = "Target repository name (the <name> part of neko32/<name>)")]
     [string]$TargetRepo
 )
 
 $SOURCE_REPO = "neko32/tanunekolab_adr"
 $TARGET_REPO = "neko32/$TargetRepo"
 
-Write-Host "コピー元: $SOURCE_REPO"
-Write-Host "コピー先: $TARGET_REPO"
+Write-Host "Source: $SOURCE_REPO"
+Write-Host "Target: $TARGET_REPO"
 Write-Host ""
 
-# コピー先リポジトリの存在確認
-$repoCheck = gh repo view $TARGET_REPO 2>&1
+# Verify target repository exists
+$repoCheck = gh repo view $TARGET_REPO
 if ($LASTEXITCODE -ne 0) {
-    Write-Error "リポジトリ '$TARGET_REPO' が見つかりません。リポジトリ名を確認してください。"
+    Write-Error "Repository '$TARGET_REPO' not found. Please check the repository name."
     exit 1
 }
 
-# コピー元のラベル一覧を取得
-Write-Host "ラベル一覧を取得中..."
-$labelsJson = gh label list --repo $SOURCE_REPO --json name,color,description --limit 100 2>&1
+# Fetch label list from source repository
+Write-Host "Fetching labels..."
+$labelsJson = gh label list --repo $SOURCE_REPO --json name,color,description --limit 100
 if ($LASTEXITCODE -ne 0) {
-    Write-Error "ラベル一覧の取得に失敗しました: $labelsJson"
+    Write-Error "Failed to fetch labels: $labelsJson"
     exit 1
 }
 
 $labels = $labelsJson | ConvertFrom-Json
 $total = $labels.Count
-Write-Host "$total 件のラベルが見つかりました。"
+Write-Host "Found $total label(s)."
 Write-Host ""
 
 $success = 0
@@ -44,25 +44,25 @@ foreach ($label in $labels) {
     $color = $label.color
     $description = $label.description
 
-    Write-Host -NoNewline "  [$name] をコピー中... "
+    Write-Host -NoNewline "  Copying [$name]... "
 
-    $result = gh label create "$name" `
+    gh label create "$name" `
         --color "$color" `
         --description "$description" `
         --repo "$TARGET_REPO" `
-        --force 2>&1
+        --force | Out-Null
 
     if ($LASTEXITCODE -eq 0) {
         Write-Host "OK"
         $success++
     } else {
-        Write-Host "失敗: $result"
+        Write-Host "FAILED"
         $failed++
     }
 }
 
 Write-Host ""
-Write-Host "完了: 成功 $success 件 / 失敗 $failed 件 (合計 $total 件)"
+Write-Host "Done: $success succeeded / $failed failed (total $total)"
 
 if ($failed -gt 0) {
     exit 1

--- a/scripts/gh_copy_labels.ps1
+++ b/scripts/gh_copy_labels.ps1
@@ -1,0 +1,69 @@
+# gh_copy_labels.ps1
+# neko32/tanunekolab_adr の issues label を指定したリポジトリにコピーする
+#
+# Usage: .\gh_copy_labels.ps1 <target_repo_name>
+# Example: .\gh_copy_labels.ps1 nekokan_music
+
+param(
+    [Parameter(Mandatory = $true, HelpMessage = "コピー先のリポジトリ名 (neko32/<name> の <name> 部分)")]
+    [string]$TargetRepo
+)
+
+$SOURCE_REPO = "neko32/tanunekolab_adr"
+$TARGET_REPO = "neko32/$TargetRepo"
+
+Write-Host "コピー元: $SOURCE_REPO"
+Write-Host "コピー先: $TARGET_REPO"
+Write-Host ""
+
+# コピー先リポジトリの存在確認
+$repoCheck = gh repo view $TARGET_REPO 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "リポジトリ '$TARGET_REPO' が見つかりません。リポジトリ名を確認してください。"
+    exit 1
+}
+
+# コピー元のラベル一覧を取得
+Write-Host "ラベル一覧を取得中..."
+$labelsJson = gh label list --repo $SOURCE_REPO --json name,color,description --limit 100 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "ラベル一覧の取得に失敗しました: $labelsJson"
+    exit 1
+}
+
+$labels = $labelsJson | ConvertFrom-Json
+$total = $labels.Count
+Write-Host "$total 件のラベルが見つかりました。"
+Write-Host ""
+
+$success = 0
+$failed = 0
+
+foreach ($label in $labels) {
+    $name = $label.name
+    $color = $label.color
+    $description = $label.description
+
+    Write-Host -NoNewline "  [$name] をコピー中... "
+
+    $result = gh label create "$name" `
+        --color "$color" `
+        --description "$description" `
+        --repo "$TARGET_REPO" `
+        --force 2>&1
+
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "OK"
+        $success++
+    } else {
+        Write-Host "失敗: $result"
+        $failed++
+    }
+}
+
+Write-Host ""
+Write-Host "完了: 成功 $success 件 / 失敗 $failed 件 (合計 $total 件)"
+
+if ($failed -gt 0) {
+    exit 1
+}


### PR DESCRIPTION
## Summary

- `neko32/tanunekolab_adr` の issues label を任意のリポジトリにコピーするユーティリティスクリプトを追加
- PowerShell (Windows用) と Bash (Linux用) の両対応
- `--force` オプションにより既存ラベルの上書き更新にも対応

## 使い方

```powershell
# Windows
.\scripts\gh_copy_labels.ps1 nekokan_music
```

```bash
# Linux
./scripts/gh_copy_labels.bash nekokan_music
```

## Test plan

- [ ] `gh_copy_labels.ps1` を実行し、対象リポジトリにラベルがコピーされることを確認
- [ ] `gh_copy_labels.bash` を実行し、対象リポジトリにラベルがコピーされることを確認
- [ ] 存在しないリポジトリ名を指定したときにエラーメッセージが表示されることを確認
- [ ] 既存ラベルがある場合に上書き更新されることを確認

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)