### PR TITLE
feat: add reusable workflow to remove in-progress label on issue close

### DIFF
--- a/.github/workflows/on-issue-closed.yml
+++ b/.github/workflows/on-issue-closed.yml
@@ -1,0 +1,13 @@
+name: On Issue Closed
+
+on:
+  issues:
+    types:
+      - closed
+
+jobs:
+  remove-in-progress:
+    uses: neko32/shared-actions/.github/workflows/remove-in-progress-on-close.yml@main
+    with:
+      issue_number: ${{ github.event.issue.number }}
+    secrets: inherit

--- a/.github/workflows/remove-in-progress-on-close.yml
+++ b/.github/workflows/remove-in-progress-on-close.yml
@@ -1,0 +1,38 @@
+name: Remove In-Progress Label on Issue Close (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      issue_number:
+        description: "The issue number to process"
+        required: true
+        type: number
+      repo:
+        description: "Repository in owner/repo format. Defaults to caller repository."
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  remove-in-progress-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Remove 'in progress' label if present
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          REPO: ${{ inputs.repo != '' && inputs.repo || github.repository }}
+        run: |
+          echo "Checking labels on issue #${ISSUE_NUMBER} in ${REPO}..."
+          labels=$(gh issue view "${ISSUE_NUMBER}" --repo "${REPO}" --json labels --jq '[.labels[].name]')
+          echo "Current labels: ${labels}"
+
+          if echo "${labels}" | jq -e 'map(select(. == "in progress")) | length > 0' > /dev/null; then
+            echo "Found 'in progress' label. Removing it..."
+            gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}" --remove-label "in progress"
+            echo "Successfully removed 'in progress' label from issue #${ISSUE_NUMBER}."
+          else
+            echo "'in progress' label not found on issue #${ISSUE_NUMBER}. Nothing to do."
+          fi


### PR DESCRIPTION
## Summary

- issue がクローズされたとき `in progress` ラベルを自動除去する Reusable Workflow を追加
- 他リポジトリから `uses: neko32/shared-actions/.github/workflows/remove-in-progress-on-close.yml@main` で呼び出し可能
- このリポジトリ自身でも `on-issue-closed.yml` で使用する構成を追加

## ファイル構成

- `.github/workflows/remove-in-progress-on-close.yml` — Reusable Workflow 本体
- `.github/workflows/on-issue-closed.yml` — このリポジトリ自身の呼び出し側（他リポジトリへのサンプル兼用）

## 他リポジトリでの使い方

```yaml
on:
  issues:
    types:
      - closed

jobs:
  remove-in-progress:
    uses: neko32/shared-actions/.github/workflows/remove-in-progress-on-close.yml@main
    with:
      issue_number: ${{ github.event.issue.number }}
    secrets: inherit
```

## Test plan

- [ ] issue に `in progress` ラベルを付与してクローズ → ラベルが除去されること
- [ ] issue に `in progress` ラベルがない状態でクローズ → 何もせず正常終了すること

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)