### PR TITLE
fix: grant issues:write permission to caller job for reusable workflow

### DIFF
--- a/.github/workflows/on-issue-closed.yml
+++ b/.github/workflows/on-issue-closed.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   remove-in-progress:
     uses: neko32/shared-actions/.github/workflows/remove-in-progress-on-close.yml@main
+    permissions:
+      issues: write
     with:
       issue_number: ${{ github.event.issue.number }}
     secrets: inherit


### PR DESCRIPTION
## Summary

- `on-issue-closed.yml` の呼び出し元ジョブに `permissions: issues: write` を追加
- Reusable Workflow 側で `issues: write` を宣言しても、呼び出し元が同権限を持っていないと GitHub に拒否されるため

## 原因

GitHub の仕様: Reusable Workflow 内の `permissions` 宣言は「要求」であり、呼び出し元ジョブが同じ権限を付与していないと `is only allowed 'issues: none'` エラーになる。

## Test plan

- [ ] issue に `in progress` ラベルを付与してクローズ → ラベルが除去されること
- [ ] issue に `in progress` ラベルがない状態でクローズ → 何もせず正常終了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)