### PR TITLE
fix: move permissions to workflow level for reusable workflow call

### DIFF
--- a/.github/workflows/on-issue-closed.yml
+++ b/.github/workflows/on-issue-closed.yml
@@ -5,11 +5,12 @@ on:
     types:
       - closed
 
+permissions:
+  issues: write
+
 jobs:
   remove-in-progress:
     uses: neko32/shared-actions/.github/workflows/remove-in-progress-on-close.yml@main
-    permissions:
-      issues: write
     with:
       issue_number: ${{ github.event.issue.number }}
     secrets: inherit


### PR DESCRIPTION
## Summary

- `on-issue-closed.yml` の `permissions` をジョブレベルからワークフローレベル（トップレベル）に移動

## 原因

GitHub の仕様では、Reusable Workflow (`uses:`) を呼び出す場合、呼び出し元の `permissions` は**ワークフローレベル**に置く必要がある。ジョブレベルの `permissions` は通常ジョブには有効だが、Reusable Workflow の呼び出しジョブには適用されない。

```
# NG: ジョブレベル（Reusable Workflow 呼び出し時は無効）
jobs:
  my-job:
    uses: ...
    permissions:
      issues: write

# OK: ワークフローレベル
permissions:
  issues: write
jobs:
  my-job:
    uses: ...
```

## Test plan

- [ ] issue に `in progress` ラベルを付与してクローズ → ラベルが除去されること
- [ ] issue に `in progress` ラベルがない状態でクローズ → 何もせず正常終了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)